### PR TITLE
Allow user to remove existing extension

### DIFF
--- a/ConvertTo-Jpeg.ps1
+++ b/ConvertTo-Jpeg.ps1
@@ -20,10 +20,10 @@ Param (
     $FixExtensionIfJpeg,
 
     [Parameter(
-        HelpMessage = "Remove existing extension of non-JPEG files before adding .jpeg")]
+        HelpMessage = "Remove existing extension of non-JPEG files before adding .jpg")]
     [Switch]
     [Alias("r")]
-    $RemoveExistingExtension
+    $RemoveOriginalExtension
 )
 
 Begin
@@ -93,18 +93,16 @@ Process
             }
             $bitmap = AwaitOperation ($decoder.GetSoftwareBitmapAsync()) ([Windows.Graphics.Imaging.SoftwareBitmap])
             
-            # Determine output file name (whether to keep or remove existing extension)
-            if ($RemoveExistingExtension)
+            # Determine output file name
+            # Get name of original file, including extension
+            $fileName = $inputFile.Name
+            if ($RemoveOriginalExtension)
             {
-                # Name new file same as old file, except change extension to jpg
-                $extension = $inputFile.FileType
-                $outputFileName = $inputFile.Name -replace ($extension + "$"), ".jpg"
+                # If removing original extension, get the original file name without the extension
+                $fileName = $inputFile.DisplayName 
             }
-            else
-            {
-                # Name new file same as old file, but add .jpg to the end
-                $outputFileName = $inputFile.Name + ".jpg";
-            }
+            # Add .jpg to the file name
+            $outputFileName = $fileName + ".jpg"
 
             # Write SoftwareBitmap to output file
             $outputFile = AwaitOperation ($inputFolder.CreateFileAsync($outputFileName, [Windows.Storage.CreationCollisionOption]::ReplaceExisting)) ([Windows.Storage.StorageFile])

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ C:\T\Pictures\IMG_5678.HEIC -> IMG_5678.HEIC.jpg
 ### Renaming Files
 
 Sometimes files have the wrong extension.
-To rename JPEG-encoded files that don't have the standard `.jpg` extension, use the `-FixExtensionIfJpeg` switch (alias `-f`).
-
-The `=>` in the output indicates that the file was renamed vs. converted.
+To rename JPEG-encoded files that don't have the standard `.jpg` extension, use the `-FixExtensionIfJpeg` 
+switch (alias `-f`). 
+(The `=>` in the output indicates that the file was renamed vs. converted.)
 
 ```PowerShell
 PS C:\T> dir C:\T\Pictures\*.HEIC | .\ConvertTo-Jpeg.ps1 -FixExtensionIfJpeg
@@ -60,12 +60,10 @@ C:\T\Pictures\IMG_1234.HEIC -> IMG_1234.HEIC.jpg
 
 ### Removing existing extensions
 
-If you want to remove the existing extension of a file, use the `-RemoveExistingExtension` switch (alias `-r`).
-
-This will not touch the original file, it will only change the output.
+To remove the existing extension of a file, use the `-RemoveOriginalExtension` switch (alias `-r`).
 
 ```PowerShell
-PS C:\T> dir C:\T\Pictures\*.HEIC | .\ConvertTo-Jpeg.ps1 -RemoveExistingExtension
+PS C:\T> dir C:\T\Pictures\*.HEIC | .\ConvertTo-Jpeg.ps1 -RemoveOriginalExtension
 C:\T\Pictures\IMG_1234.HEIC -> IMG_1234.jpg
 C:\T\Pictures\IMG_5678.HEIC -> IMG_5678.jpg
 ```

--- a/README.md
+++ b/README.md
@@ -48,13 +48,26 @@ C:\T\Pictures\IMG_5678.HEIC -> IMG_5678.HEIC.jpg
 ### Renaming Files
 
 Sometimes files have the wrong extension.
-To rename JPEG-encoded files that don't have the standard `.jpg` extension, use the `-FixExtensionIfJpeg` switch.
-(The `=>` in the output indicates that the file was renamed vs. converted.)
+To rename JPEG-encoded files that don't have the standard `.jpg` extension, use the `-FixExtensionIfJpeg` switch (alias `-f`).
+
+The `=>` in the output indicates that the file was renamed vs. converted.
 
 ```PowerShell
 PS C:\T> dir C:\T\Pictures\*.HEIC | .\ConvertTo-Jpeg.ps1 -FixExtensionIfJpeg
 C:\T\Pictures\IMG_1234 (Edited).HEIC => IMG_1234 (Edited).jpg
 C:\T\Pictures\IMG_1234.HEIC -> IMG_1234.HEIC.jpg
+```
+
+### Removing existing extensions
+
+If you want to remove the existing extension of a file, use the `-RemoveExistingExtension` switch (alias `-r`).
+
+This will not touch the original file, it will only change the output.
+
+```PowerShell
+PS C:\T> dir C:\T\Pictures\*.HEIC | .\ConvertTo-Jpeg.ps1 -RemoveExistingExtension
+C:\T\Pictures\IMG_1234.HEIC -> IMG_1234.jpg
+C:\T\Pictures\IMG_5678.HEIC -> IMG_5678.jpg
 ```
 
 ## Formats


### PR DESCRIPTION
This PR adds a switch to allow the user to remove the existing file extension before adding `.jpg`, rather than just adding `.jpg` to the end of it.

Without the switch:
```Powershell
Img123.heic -> Img123.heic.jpg
```

With the switch enabled:
```Powershell
Img123.heic -> Img123.jpg
```