### PR TITLE
Various Changes and Improvements, Additional Flags

### DIFF
--- a/ConvertTo-Jpeg.ps1
+++ b/ConvertTo-Jpeg.ps1
@@ -3,7 +3,7 @@
 
 Param (
     [Parameter(
-        Mandatory = $true,
+        Mandatory = $false,
         Position = 1,
         ValueFromPipeline = $true,
         ValueFromPipelineByPropertyName = $true,
@@ -14,9 +14,27 @@ Param (
     $Files,
 
     [Parameter(
+        HelpMessage = "Output folder for converted files")]
+    [String]
+    [Alias("o")]
+    $OutputFolderPath,
+
+    [Parameter(
         HelpMessage = "Fix extension of JPEG files without the .jpg extension")]
     [Switch]
-    $FixExtensionIfJpeg
+    $FixExtensionIfJpeg,
+
+    [Parameter(
+        HelpMessage = "Opens dialogs for input files and output folder if not supplied")]
+    [Switch]
+    [Alias("t")]
+    $InteractiveMode,
+
+    [Parameter(
+        HelpMessage = "Also output unconverted image files to the output folder path")]
+    [Switch]
+    [Alias("u")]
+    $OutputUnconverted
 )
 
 Begin
@@ -46,6 +64,43 @@ Begin
 
 Process
 {
+    # If no files were passed and interactive mode, open a file dialog to select them
+    if (!$Files -and $InteractiveMode)
+    {
+        Add-Type -AssemblyName System.Windows.Forms
+        $FileBrowser = New-Object System.Windows.Forms.OpenFileDialog -Property @{
+            InitialDirectory = [Environment]::GetFolderPath('Desktop') 
+            Title            = "Select Files to Convert"
+            Multiselect      = $true
+            # filter selection to supported filetypes
+            Filter           = "Image Files (*.*)|*.BMP;*.DIB;*.RLE;*.CUR;*.DDS;*.DNG;*.GIF;*.ICO;*.ICON;*.EXIF;*.JFIF;*.JPE;*.JPEG;*.JPG;*.ARW;*.CR2;*.CRW;*.DNG;*.ERF;*.KDC;*.MRW;*.NEF;*.NRW;*.ORF;*.PEF;*.RAF;*.RAW;*.RW2;*.RWL;*.SR2;*.SRW;*.AVCI;*.AVCS;*.HEIC;*.HEICS;*.HEIF;*.HEIFS;*.WEBP;*.PNG;*.TIF;*.TIFF;*.JXR;*.WDP|All files (*.*)|*.*"
+        }
+        $null = $FileBrowser.ShowDialog()
+        $Files = $FileBrowser.FileNames
+        $FileBrowser.Dispose()
+    }
+
+    # If no output folder selected and interactive mode, select a folder with dialog
+    if (!$OutputFolderPath -and $InteractiveMode)
+    {
+        Add-Type -AssemblyName System.Windows.Forms
+        $OutputFolderBrowser = New-Object System.Windows.Forms.FolderBrowserDialog -Property @{
+            Description = "Select Folder to Place Converted Files"
+        }
+        $null = $OutputFolderBrowser.ShowDialog()
+        $OutputFolderPath = $OutputFolderBrowser.SelectedPath
+        $OutputFolderBrowser.Dispose()
+
+        # If no OutputFolderPath was selected, Throw Error
+        if (!$OutputFolderPath)
+        {
+            Throw "Output Folder Not Selected."
+        }
+    }
+
+    # Files that failed to be converted
+    $FailedFiles = New-Object -TypeName "System.Collections.ArrayList"
+
     # Summary of imaging APIs: https://docs.microsoft.com/en-us/windows/uwp/audio-video-camera/imaging
     foreach ($file in $Files)
     {
@@ -54,10 +109,18 @@ Process
         {
             try
             {
-                # Get SoftwareBitmap from input file
+                # Get SoftwareBitmap from input file, determine output path
                 $file = Resolve-Path -LiteralPath $file
                 $inputFile = AwaitOperation ([Windows.Storage.StorageFile]::GetFileFromPathAsync($file)) ([Windows.Storage.StorageFile])
                 $inputFolder = AwaitOperation ($inputFile.GetParentAsync()) ([Windows.Storage.StorageFolder])
+                $inputExtension = $inputFile.FileType
+                $outputFolder = $inputFolder
+                $outputFileName = $inputFile.Name + ".jpg";
+
+                if ($OutputFolderPath)
+                {
+                    $outputFolder = AwaitOperation ([Windows.Storage.StorageFolder]::GetFolderFromPathAsync($OutputFolderPath)) ([Windows.Storage.StorageFolder])
+                }
                 $inputStream = AwaitOperation ($inputFile.OpenReadAsync()) ([Windows.Storage.Streams.IRandomAccessStreamWithContentType])
                 $decoder = AwaitOperation ([Windows.Graphics.Imaging.BitmapDecoder]::CreateAsync($inputStream)) ([Windows.Graphics.Imaging.BitmapDecoder])
             }
@@ -67,28 +130,49 @@ Process
                 Write-Host " [Unsupported]"
                 continue
             }
+            # Check if image is already a jpg
             if ($decoder.DecoderInformation.CodecId -eq [Windows.Graphics.Imaging.BitmapDecoder]::JpegDecoderId)
             {
-                $extension = $inputFile.FileType
-                if ($FixExtensionIfJpeg -and ($extension -ne ".jpg") -and ($extension -ne ".jpeg"))
+                # Check if jpg files should have their extensions fixed
+                $ExtensionRequiresFix = $FixExtensionIfJpeg -and ($inputExtension -ne ".jpg") -and ($inputExtension -ne ".jpeg")
+                if ($ExtensionRequiresFix)
                 {
-                    # Rename JPEG-encoded files to have ".jpg" extension
-                    $newName = $inputFile.Name -replace ($extension + "$"), ".jpg"
-                    AwaitAction ($inputFile.RenameAsync($newName))
-                    Write-Host " => $newName"
+                    $outputFileName = $inputFile.DisplayName + ".jpg"
                 }
                 else
                 {
-                    # Skip JPEG-encoded files
-                    Write-Host " [Already JPEG]"
+                    $outputFileName = $inputFile.Name
                 }
-                continue
+
+                # If OutputUnconverted and there is an OutputFolderPath
+                # Copy the existing file to the output folder
+                if ($OutputUnconverted -and $OutputFolderPath)
+                {
+                    # Copy input file to output folder
+                    Copy-Item -path $inputFile.Path -Destination $(Join-Path $outputFolder.Path $outputFileName)
+                    Write-Host " => $(Join-Path $outputFolder.Path $outputFileName)"
+                    continue
+                }
+                else
+                {
+                    if ($ExtensionRequiresFix)
+                    {
+                        # Rename JPEG-encoded files to have ".jpg" extension
+                        AwaitAction ($inputFile.RenameAsync($outputFileName))
+                        Write-Host " => $(Join-Path $inputFolder.Path $outputFileName)"
+                    }
+                    else
+                    {
+                        # Skip JPEG-encoded files
+                        Write-Host " [Already JPEG]"
+                    }
+                    continue
+                }
             }
             $bitmap = AwaitOperation ($decoder.GetSoftwareBitmapAsync()) ([Windows.Graphics.Imaging.SoftwareBitmap])
 
             # Write SoftwareBitmap to output file
-            $outputFileName = $inputFile.Name + ".jpg";
-            $outputFile = AwaitOperation ($inputFolder.CreateFileAsync($outputFileName, [Windows.Storage.CreationCollisionOption]::ReplaceExisting)) ([Windows.Storage.StorageFile])
+            $outputFile = AwaitOperation ($outputFolder.CreateFileAsync($outputFileName, [Windows.Storage.CreationCollisionOption]::ReplaceExisting)) ([Windows.Storage.StorageFile])
             $outputStream = AwaitOperation ($outputFile.OpenAsync([Windows.Storage.FileAccessMode]::ReadWrite)) ([Windows.Storage.Streams.IRandomAccessStream])
             $encoder = AwaitOperation ([Windows.Graphics.Imaging.BitmapEncoder]::CreateAsync([Windows.Graphics.Imaging.BitmapEncoder]::JpegEncoderId, $outputStream)) ([Windows.Graphics.Imaging.BitmapEncoder])
             $encoder.SetSoftwareBitmap($bitmap)
@@ -96,18 +180,29 @@ Process
 
             # Do it
             AwaitAction ($encoder.FlushAsync())
-            Write-Host " -> $outputFileName"
+            Write-Host " -> $(Join-Path $outputFolder.Path $outputFileName)"
         }
         catch
         {
-            # Report full details
-            throw $_.Exception.ToString()
+            # Report full details and add file to list
+            Write-Error $_.Exception
+            $FailedFiles.Add($file)
         }
         finally
         {
             # Clean-up
             if ($inputStream -ne $null) { [System.IDisposable]$inputStream.Dispose() }
             if ($outputStream -ne $null) { [System.IDisposable]$outputStream.Dispose() }
+        }
+    }
+
+    if ($FailedFiles.Count -gt 0)
+    {
+        Write-Host "The following files failed to convert."
+        Write-Host "You may lack the required extensions or the files may be corrupt."
+        foreach ($file in $FailedFiles)
+        {
+            Write-Host $file
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -23,16 +23,16 @@ Passing parameters:
 
 ```PowerShell
 PS C:\T> .\ConvertTo-Jpeg.ps1 C:\T\Pictures\IMG_1234.HEIC C:\T\Pictures\IMG_5678.HEIC
-C:\T\Pictures\IMG_1234.HEIC -> IMG_1234.HEIC.jpg
-C:\T\Pictures\IMG_5678.HEIC -> IMG_5678.HEIC.jpg
+C:\T\Pictures\IMG_1234.HEIC -> C:\T\Pictures\IMG_1234.HEIC.jpg
+C:\T\Pictures\IMG_5678.HEIC -> C:\T\Pictures\IMG_5678.HEIC.jpg
 ```
 
 Pipeline via `dir`:
 
 ```PowerShell
 PS C:\T> dir C:\T\Pictures | .\ConvertTo-Jpeg.ps1
-C:\T\Pictures\IMG_1234.HEIC -> IMG_1234.HEIC.jpg
-C:\T\Pictures\IMG_5678.HEIC -> IMG_5678.HEIC.jpg
+C:\T\Pictures\IMG_1234.HEIC -> C:\T\Pictures\IMG_1234.HEIC.jpg
+C:\T\Pictures\IMG_5678.HEIC -> C:\T\Pictures\IMG_5678.HEIC.jpg
 C:\T\Pictures\Kitten.jpg [Already JPEG]
 C:\T\Pictures\Notes.txt [Unsupported]
 ```
@@ -41,9 +41,40 @@ Pipeline via `Get-ChildItem`:
 
 ```PowerShell
 PS C:\T> Get-ChildItem C:\T\Pictures -Filter *.HEIC | .\ConvertTo-Jpeg.ps1
-C:\T\Pictures\IMG_1234.HEIC -> IMG_1234.HEIC.jpg
-C:\T\Pictures\IMG_5678.HEIC -> IMG_5678.HEIC.jpg
+C:\T\Pictures\IMG_1234.HEIC -> C:\T\Pictures\IMG_1234.HEIC.jpg
+C:\T\Pictures\IMG_5678.HEIC -> C:\T\Pictures\IMG_5678.HEIC.jpg
 ```
+
+Dialog via `InteractiveMode` (`-t`) flag:
+
+```PowerShell
+PS C:\T> .\ConvertTo-Jpeg.ps1 -t
+C:\T\Pictures\IMG_1234.HEIC -> C:\T\Pictures\IMG_1234.HEIC.jpg
+C:\T\Pictures\IMG_5678.HEIC -> C:\T\Pictures\IMG_5678.HEIC.jpg
+```
+
+
+### Output Folder
+
+Choosing an output folder path for converted files.
+If no output path is supplied, each converted file will be placed in the same
+folder as the original.
+If an output path is supplied, it will be included in the file conversion log.
+
+Paramater via `OutputFolderPath` (`-o`) flag:
+
+```PowerShell
+PS C:\T> .\ConvertTo-Jpeg.ps1 -o C:\T\Documents C:\T\Pictures\IMG_1234.HEIC
+C:\T\Pictures\IMG_1234.HEIC -> C:\T\Documents\IMG_1234.HEIC.jpg
+```
+
+Dialog via `InteractiveMode` (`-t`) flag:
+
+```PowerShell
+PS C:\T> .\ConvertTo-Jpeg.ps1 -t C:\T\Pictures\IMG_1234.HEIC
+C:\T\Pictures\IMG_1234.HEIC -> C:\T\Documents\IMG_1234.HEIC.jpg
+```
+
 
 ### Renaming Files
 
@@ -53,9 +84,22 @@ To rename JPEG-encoded files that don't have the standard `.jpg` extension, use 
 
 ```PowerShell
 PS C:\T> dir C:\T\Pictures\*.HEIC | .\ConvertTo-Jpeg.ps1 -FixExtensionIfJpeg
-C:\T\Pictures\IMG_1234 (Edited).HEIC => IMG_1234 (Edited).jpg
-C:\T\Pictures\IMG_1234.HEIC -> IMG_1234.HEIC.jpg
+C:\T\Pictures\IMG_ABCD.HEIC => C:\T\Pictures\IMG_ABCD.jpg
+C:\T\Pictures\IMG_1234.HEIC -> C:\T\Pictures\IMG_1234.HEIC.jpg
 ```
+
+### Output Unconverted Files
+
+Also outputs existing files that don't require conversion but are images
+if an output path is specified by `-o` flag or InteractiveMode (`-t`).
+This includes existing JPEG-encoded files.
+
+```PowerShell
+PS C:\T> .\ConvertTo-Jpeg.ps1 -o C:\T\Documents C:\T\Pictures\IMG_1234.HEIC C:\T\Pictures\IMG_ABCD.jpg
+C:\T\Pictures\IMG_1234.HEIC -> C:\T\Documents\IMG_1234.HEIC.jpg
+C:\T\Pictures\IMG_ABCD.jpg => C:\T\Documents\IMG_5678.jpg
+```
+
 
 ## Formats
 


### PR DESCRIPTION
Various changes and improvements. Changes should all be backwards compatible and behind flags, should be almost no change in behavior unless the new flags are used. Open to feedback, feel free to merge as is, cherry-pick, or reject. Changes include:

- Adding an output folder parameter (`-OutputFolderPath`,`-o`) to select an output folder separate from the input file.
- Added a flag (`-OutputUnconverted`, `-u`) which will copy image files already in the converted format, jpeg, to the output folder if it is specified.
- Added an interactive mode flag (`-InteractiveMode`, `-t`) which will open dialog file pickers for input files and output folder if they are not specified in a parameter.
- Added a flag to allow file conversion to continue on a failed convert (`-NoFailOnConvert`). Files that failed to convert are printed in a message at the end of the script.
- File logging now includes the full output file path, since it may be different from the input file.